### PR TITLE
chore: remove sectigo import in link validator

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Add additional root certs
         run: |
           JAVA_HOME=$(cs java-home --jvm adopt:11)
-          keytool -importcert -trustcacerts -storepass changeit -alias sectigo -keystore $JAVA_HOME/lib/security/cacerts -file .additional-certs/Sectigo_RSA_Domain_Validation_Secure_server_CA.cer
           keytool -importcert -trustcacerts -storepass changeit -alias gts_ca_1p5 -keystore $JAVA_HOME/lib/security/cacerts -file .additional-certs/GTS_CA_1P5.cer
 
       - name: sbt site

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -25,11 +25,6 @@ jobs:
           jvm: temurin:1.17.0.5
           apps: cs
 
-      - name: Add additional root certs
-        run: |
-          JAVA_HOME=$(cs java-home --jvm adopt:11)
-          keytool -importcert -trustcacerts -storepass changeit -alias gts_ca_1p5 -keystore $JAVA_HOME/lib/security/cacerts -file .additional-certs/GTS_CA_1P5.cer
-
       - name: sbt site
         run: sbt docs/makeSite
 


### PR DESCRIPTION
Was failing here: https://github.com/akka/akka-dependencies/pull/74