### PR TITLE
build: Bump sbt plugins to only download from maven central

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.19.0")
 // docs
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.53")
-addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.54")
+addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.3")
 addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0")


### PR DESCRIPTION
As the other repos are unstable/going away: https://contributors.scala-lang.org/t/roadmap-for-the-sbt-community-repository/6195
