### PR TITLE
fix: make cinnamon actually compatible with the current akka version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
-addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.19.0")
+addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.19.3")
 // docs
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.54")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.3")


### PR DESCRIPTION
The release of akka-dependencies `23.10.0` brings in akka `2.9.1` and cinnamon `2.19.0` where the latter is not compatible with the former: https://developer.lightbend.com/docs/telemetry/current//project/release-notes.html#lightbend-telemetry-2-19-2

