### PR TITLE
docs: align akka versions in akka-guide samples during release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@ This repository will release to https://repo.akka.io/maven.
 1. To initiate a release push a tag prefixed with `v`, i.e. `v22.10.0`.
 1. Update the "current" link on Gustav. `ln -snf ${VERSION} current`
 1. Update example projects referencing this BOM.
-  * https://github.com/akka/akka-platform-guide
+  * https://github.com/lightbend/akka-guide
+  * If the recent release of this BOM does bump akka, make sure to align all akka versions in `akka-guide`.
 
 NOTE: User sonatype tokens are used. Update `PUBLISH_USER` and `PUBLISH_PASSWORD` repository secrets if necessary.


### PR DESCRIPTION
Came up during https://github.com/lightbend/akka-guide/pull/915.