### PR TITLE
chore: add missing modules

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,7 +75,10 @@ object Dependencies {
     "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagement,
     "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagement,
     "com.lightbend.akka.management" %% "akka-management-loglevels-logback" % AkkaManagement,
+    "com.lightbend.akka.management" %% "akka-management-loglevels-log4j2" % AkkaManagement,
+    "com.lightbend.akka.management" %% "akka-management-pki" % AkkaManagement,
     "com.lightbend.akka.management" %% "akka-lease-kubernetes" % AkkaManagement,
+    "com.lightbend.akka.management" %% "akka-rolling-update-kubernetes" % AkkaManagement,
     "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % AkkaManagement)
 
   val akkaProjections = Seq(


### PR DESCRIPTION
There are a few also missing under `com.lightbend.akka.discovery`: https://repo.akka.io/maven/com/lightbend/akka/discovery/

Should we add them as well?