### PR TITLE
chore: license for release of 24.10.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ Parameters
 
 Licensor:             Lightbend, Inc.
 Licensed Work:        Akka Dependencies 24.10.x
-                      The Licensed Work is (c) 2023 Lightbend Inc.
+                      The Licensed Work is (c) 2024 Lightbend Inc.
 Additional Use Grant:
     If you develop an application using a version of Play Framework that
     utilizes binary versions of akka-streams and its dependencies, you may
@@ -15,7 +15,7 @@ Additional Use Grant:
     Connecting to a Play Framework websocket and/or Play Framework
     request/response bodies for server and play-ws client.
 
-Change Date:          2026-11-05
+Change Date:          2027-11-05
 
 Change License:       Apache License, Version 2.0
 

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Lightbend, Inc.
-Licensed Work:        Akka Dependencies 23.10.x
+Licensed Work:        Akka Dependencies 24.10.x
                       The Licensed Work is (c) 2023 Lightbend Inc.
 Additional Use Grant:
     If you develop an application using a version of Play Framework that
@@ -15,7 +15,7 @@ Additional Use Grant:
     Connecting to a Play Framework websocket and/or Play Framework
     request/response bodies for server and play-ws client.
 
-Change Date:          2026-10-25
+Change Date:          2026-11-05
 
 Change License:       Apache License, Version 2.0
 


### PR DESCRIPTION
Also correcting the version I missed for the initial release of `24.10.0`.