### PR TITLE
Replace hardcoded repo.akka.io/maven references in docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,9 @@ jobs:
         # https://github.com/coursier/cache-action/releases
         uses: coursier/cache-action@v8.1.0
 
+      - name: Setup global resolver
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Check scalafmt rules, publish BOM locally
         run: sbt checkBom
 

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -28,6 +28,9 @@ jobs:
           jvm: temurin:1.17
           apps: cs
 
+      - name: Setup global resolver
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: sbt site
         run: sbt docs/makeSite
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
         # https://github.com/coursier/cache-action/releases
         uses: coursier/cache-action@v8.1.0
 
+      - name: Setup global resolver
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Check scalafmt rules, pull dependencies, publish BOM locally successfully
         env:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add a `dependencyManagement` `dependency` to your `pom.xml`:
         <repository>
             <id>akka-repository</id>
             <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven</url>
+            <url><url from https://account.akka.io/token></url>
         </repository>
     </repositories>
     <dependencyManagement>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release
 
-This repository will release to https://repo.akka.io/maven.
+This repository will release to the Akka repository (accessible via token from https://account.akka.io/token).
 
 1. Check the `AkkaDependenciesMinor` version in `project/Dependencies.scala`
 1. To initiate a release push a tag prefixed with `v`, i.e. `v22.10.0`.

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import Dependencies._
 import com.geirsson.CiReleasePlugin
 import sbtdynver.DynVerPlugin.autoImport.dynverSonatypeSnapshots
 
-ThisBuild / resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
 ThisBuild / resolvers ++= sys.env
   .get("LIGHTBEND_COMMERCIAL_MVN")
   .map { repo =>
@@ -46,7 +45,6 @@ lazy val `akka-dependencies` =
         alpakka ++
         akkaDiagnostics ++
         telemetry,
-      resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions"),
       // to check that all dependencies can be pulled and there are no conflicts
       libraryDependencies ++= {
         val bomDeps = bomIncludeModules.value

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -39,7 +39,7 @@ Akka is licensed under the Business Source License 1.1, please see [Akka License
 @@repository [Maven,sbt,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/{your repository token here}/secure"
+url="<url from https://account.akka.io/token>"
 }
 
 ## Akka (core) $akka.version$  
@@ -130,14 +130,14 @@ Maven
         <repository>
           <id>akka-repository</id>
           <name>Akka library repository</name>
-          <url>https://repo.akka.io/{your repository token here}/secure</url>
+          <url><url from https://account.akka.io/token></url>
         </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
           <id>akka-repository</id>
           <name>Akka library repository</name>
-          <url>https://repo.akka.io/{your repository token here}/secure</url>
+          <url><url from https://account.akka.io/token></url>
         </pluginRepository>
       </pluginRepositories>
       <dependencies>
@@ -171,11 +171,11 @@ sbt
 :   @@@vars
     ```scala
     // in project/plugins.sbt:
-    resolvers += "Akka library repository".at("https://repo.akka.io/{your repository token here}/secure")
+    resolvers += "Akka library repository".at("<url from https://account.akka.io/token>")
     addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "$akka-grpc.version$")
     //
     // in build.sbt:
-    resolvers += "Akka library repository".at("https://repo.akka.io/{your repository token here}/secure")
+    resolvers += "Akka library repository".at("<url from https://account.akka.io/token>")
     enablePlugins(AkkaGrpcPlugin)
     ```
 @@@
@@ -187,7 +187,7 @@ Gradle
       repositories {
         gradlePluginPortal()
         maven {
-          url "https://repo.akka.io/{your repository token here}/secure"
+          url "<url from https://account.akka.io/token>"
         }
       }
     }
@@ -199,7 +199,7 @@ Gradle
     repositories {
       mavenCentral()
       maven {
-        url "https://repo.akka.io/{your repository token here}/secure"
+        url "<url from https://account.akka.io/token>"
       }
     }
     ```

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")


### PR DESCRIPTION
## Summary

The bare \`https://repo.akka.io/maven\` URL requires token-based access from https://account.akka.io/token.

**\`README.md\`**
Replace resolver URL in the Maven BOM usage example with \`<url from https://account.akka.io/token>\`.

**\`RELEASE.md\`**
Describe the publish destination generically ("the Akka repository") with a pointer to https://account.akka.io/token for access.

**Not changed:** \`build.sbt\` and \`project/plugins.sbt\` use \`repo.akka.io/maven/github_actions\`, which is a CI-specific endpoint — leaving that for a separate discussion.