### PR TITLE
feat: duplicate BOM dependencies for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val `akka-dependencies` =
     .disablePlugins(CiReleasePlugin)
     .settings(
       crossScalaVersions := Versions.CrossScalaVersions,
+      crossVersion := CrossVersion.disabled,
       scalaVersion := Versions.Scala213,
       organization := "com.lightbend.akka",
       name := "akka-dependencies",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,9 +3,8 @@ import sbt._
 object Dependencies {
   object Versions {
     val Scala213 = "2.13.17"
-    val CrossScalaVersions = Seq(Scala213)
-
-    val Scala3 = "3.3"
+    val Scala3 = "3"
+    val CrossScalaVersions = Seq(Scala213, Scala3)
 
     // To update Cinnamon version, change the plugin version
     // in project/plugins.sbt


### PR DESCRIPTION
This (a little hacky) change will make the BOM include all dependencies even with the Scala 3 postfix:

```xml
            <dependency>
                <groupId>com.typesafe.akka</groupId>
                <artifactId>akka-actor_2.13</artifactId>
                <version>2.10.20</version>
            </dependency>
            <dependency>
                <groupId>com.typesafe.akka</groupId>
                <artifactId>akka-actor_3</artifactId>
                <version>2.10.20</version>
            </dependency>
```



<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References
- https://github.com/lightbend/sbt-bill-of-materials#create-a-single-bom-for-all-scala-versions