### PR TITLE
bump: bill-of-materials 1.1.1 (Scala 3 support)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   object Versions {
     val Scala213 = "2.13.17"
-    val Scala3 = "3"
+    val Scala3 = "3.3"
     val CrossScalaVersions = Seq(Scala213, Scala3)
 
     // To update Cinnamon version, change the plugin version

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
+addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.1.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.22.3")
 // docs


### PR DESCRIPTION
Use the updated plugin with proper support for Scala 3.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References
- https://github.com/lightbend/sbt-bill-of-materials/pull/13
- https://github.com/akka/akka-dependencies/pull/212
