### PR TITLE
fix: unblock release on Scala 3 (Cinnamon/Jackson cross-version conflict)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,12 +49,18 @@ lazy val `akka-dependencies` =
       // to check that all dependencies can be pulled and there are no conflicts
       libraryDependencies ++= {
         val bomDeps = bomIncludeModules.value
-        if (sys.env.contains("LIGHTBEND_COMMERCIAL_MVN")) {
-          bomDeps
-        } else {
-          // Run the validation for at least the non-commercial dependencies
-          bomDeps.filterNot(allCommercialLibs.contains)
-        }
+        val deps =
+          if (sys.env.contains("LIGHTBEND_COMMERCIAL_MVN")) {
+            bomDeps
+          } else {
+            // Run the validation for at least the non-commercial dependencies
+            bomDeps.filterNot(allCommercialLibs.contains)
+          }
+        // cinnamon-opentracing-datadog hardcodes a dependency on jackson-module-scala_2.13, which
+        // collides with jackson-module-scala_3 (from akka-serialization-jackson) when resolving the
+        // Scala 3 cross-build. Skip it in this resolution check only; it stays in the published BOM
+        // because bomIncludeModules is unchanged.
+        deps.filterNot(m => m.organization == "com.lightbend.cinnamon" && m.name == "cinnamon-opentracing-datadog")
       },
       publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true),
       publishM2Configuration := publishM2Configuration.value.withOverwrite(true))

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -6,6 +6,7 @@ This table lists all Akka libraries that are part of the Akka $akka-dependencies
 
 Akka $akka-dependencies.version$ is cross-built for Scala $akka-scala-2.13.version$ and Scala $akka-scala-3.version$. 
 Akka is certified for use with certain Java versions, see @ref[Java Versions](java-versions.md).
+See @ref[Known issues](known-issues.md) for a Scala 3 conflict between Lightbend Telemetry and Jackson, and how to work around it.
 
 Some libraries in Akka do not live up to the high standards we require to fully support them for Akka Licensees. Libraries are marked with their @ref[readiness level](support-terminology.md) in the "project info" section of their documentation.
 
@@ -390,5 +391,6 @@ Move your endpoints to the edge of the cloud for lower latency and higher availa
 * [overview](overview.md)
 * [java-version](java-versions.md)
 * [support-terminology](support-terminology.md)
+* [known-issues](known-issues.md)
 
 @@@

--- a/docs/src/main/paradox/known-issues.md
+++ b/docs/src/main/paradox/known-issues.md
@@ -1,0 +1,54 @@
+# Known issues
+
+## Scala 3: conflict between Lightbend Telemetry and Jackson
+
+Lightbend Telemetry's `cinnamon-opentracing-datadog` module (up to and including `2.22.3`) is
+published as a plain Java artifact but declares a compile-scope dependency on the Scala 2.13 build
+of Jackson, `com.fasterxml.jackson.module:jackson-module-scala_2.13`. Because that suffix is fixed
+in the artifact's POM, it is pulled regardless of the Scala version your project builds with.
+
+On **Scala 3**, any project that also depends on `akka-serialization-jackson` (directly or
+transitively) pulls `jackson-module-scala_3`, so both cross-version variants of the module end up on
+the classpath:
+
+* with **sbt**, resolution fails with
+  `Conflicting cross-version suffixes in: com.fasterxml.jackson.module:jackson-module-scala (_3, _2.13)`;
+* with **Maven** and **Gradle**, the build succeeds but ships both `jackson-module-scala_2.13` and
+  `jackson-module-scala_3`, which is a latent runtime hazard.
+
+Only the `cinnamon-opentracing-datadog` module is affected — every other Lightbend Telemetry module
+resolves cleanly on Scala 3. A fix is being tracked in Lightbend Telemetry.
+
+### Workaround
+
+Until a fixed Lightbend Telemetry release is available, exclude the Scala 2.13 Jackson module from
+`cinnamon-opentracing-datadog` in your own build. This is safe on Scala 3: `akka-serialization-jackson`
+already provides `jackson-module-scala_3`.
+
+sbt
+:   ```scala
+    ("com.lightbend.cinnamon" % "cinnamon-opentracing-datadog" % cinnamonVersion)
+      .exclude("com.fasterxml.jackson.module", "jackson-module-scala_2.13")
+    ```
+
+Maven
+:   ```xml
+    <dependency>
+      <groupId>com.lightbend.cinnamon</groupId>
+      <artifactId>cinnamon-opentracing-datadog</artifactId>
+      <version>${cinnamon.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_2.13</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    ```
+
+Gradle
+:   ```gradle
+    implementation("com.lightbend.cinnamon:cinnamon-opentracing-datadog:${cinnamonVersion}") {
+        exclude group: "com.fasterxml.jackson.module", module: "jackson-module-scala_2.13"
+    }
+    ```


### PR DESCRIPTION
Release has been failing on `main` since Scala 3 was added to the cross-build (#212): `sbt checkPullBom` aborts on the Scala 3.3.7 pass with

```
Conflicting cross-version suffixes in: com.fasterxml.jackson.module:jackson-module-scala (_3, _2.13)
```

`cinnamon-opentracing-datadog` hardcodes a compile-scope `jackson-module-scala_2.13`, which collides with `jackson-module-scala_3` (from `akka-serialization-jackson`) on Scala 3. Upstream bug: lightbend/cinnamon#3428.

- **build.sbt** — skip that one module in the resolution check only. `bomIncludeModules` is untouched, so the published BOM still lists it and carries no exclusions (exclusion-based fixes leak into the BOM via sbt-bill-of-materials, and would break Scala 2.13 consumers).
- **docs** — a Known issues page with the per-build-tool exclusion workaround, until the Cinnamon fix ships.
