### PR TITLE
Release BOM just once

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           PUBLISH_USER: ${{ secrets.PUBLISH_USER }}
           PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
-        run: sbt +publishSigned
+        run: sbt publishSigned
 
   documentation:
     name: Documentation


### PR DESCRIPTION
Run publish only once so it doesn't try to publish two identical BOM files.

```
[info] Setting Scala version to 2.13.18 on 2 projects.
[info] Reapplying settings...
[info] set current project to akka-dependencies (in build file:/home/runner/work/akka-dependencies/akka-dependencies/)
...
[info] 	published akka-dependencies to https://maven.cloudsmith.io/lightbend/akka/com/lightbend/akka/akka-dependencies/25.10.11/akka-dependencies-25.10.11.pom
[info] 	published akka-dependencies to https://maven.cloudsmith.io/lightbend/akka/com/lightbend/akka/akka-dependencies/25.10.11/akka-dependencies-25.10.11.pom.asc
[success] Total time: 6 s, completed Aug 3, 2026, 1:09:06 PM
...
[info] Setting Scala version to 3.3.7 on 1 projects.
[info] Excluded 1 projects, run ++ 3.3.7 -v for more details.
[info] Reapplying settings...
[info] set current project to akka-dependencies (in build file:/home/runner/work/akka-dependencies/akka-dependencies/)
...
[info] 	published akka-dependencies to https://maven.cloudsmith.io/lightbend/akka/com/lightbend/akka/akka-dependencies/25.10.11/akka-dependencies-25.10.11.pom
[info] 	published akka-dependencies to https://maven.cloudsmith.io/lightbend/akka/com/lightbend/akka/akka-dependencies/25.10.11/akka-dependencies-25.10.11.pom.asc
```